### PR TITLE
Integrate Real Quantum Counts from Grover’s Algorithm

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,12 +8,14 @@ from graph_data import get_demo_graph, get_large_graph, get_city_graph
 # --- Initial setup ---
 G, pos = get_demo_graph()
 start_node, end_node = "A", "D"
-best_path, quantum_counts = quantum_optimize(G, start_node, end_node)
+k_candidates = 10  # default number of candidate paths for Grover
+best_path, quantum_counts, quantum_shots = quantum_optimize(G, start_node, end_node, k=k_candidates)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 9))
 plt.subplots_adjust(left=0.05, right=0.95, bottom=0.25)  # space for widgets
 
 # --- Traffic-aware vehicles ---
+# nodes = intersections, edges = roads, weights = travel time
 traffic_penalty = 1
 traffic = {}  # edge -> number of vehicles on it
 vehicles = []
@@ -22,17 +24,26 @@ def select_path():
     """Select path based on quantum counts and traffic congestion"""
     all_paths = list(nx.all_simple_paths(G, start_node, end_node))
     path_weights = []
+    # safe epsilon for zero-count paths
+    eps = 1e-6
     for idx, path in enumerate(all_paths):
         cost = 0
         for u, v in zip(path[:-1], path[1:]):
             w = G[u][v]['weight']
             t = traffic.get((u, v), 0)
             cost += w + t * traffic_penalty
-        quantum_prob = quantum_counts.get(idx, 1)
-        cost /= quantum_prob  # bias towards higher quantum counts
+        # use measured probability (counts / shots). if quantum_shots not available, fallback to 1
+        if 'quantum_shots' in globals() and quantum_shots:
+            qcount = quantum_counts.get(idx, 0)
+            qprob = max(qcount / quantum_shots, eps)
+        else:
+            qprob = 1.0
+        # bias toward higher quantum probability by reducing effective cost
+        cost /= qprob
         path_weights.append(cost)
     min_idx = path_weights.index(min(path_weights))
     return all_paths[min_idx]
+
 
 def init_vehicles(n):
     """Initialize vehicles with unique colors and assigned paths"""
@@ -58,12 +69,11 @@ def animate(frame):
     for edge in G.edges():
         traffic[edge] = 0
 
-    # Update traffic based on current vehicle positions
+    # Update vehicle positions
     for v in vehicles:
         path_nodes = v["path"]
         total_edges = len(path_nodes) - 1
 
-        # Loop back after reaching destination
         if v["pos"] >= 1.0:
             v["pos"] = 0.0
             v["path"] = select_path()
@@ -77,24 +87,22 @@ def animate(frame):
         edge = (path_nodes[edge_idx], path_nodes[edge_idx + 1])
         traffic[edge] = traffic.get(edge, 0) + 1
 
-        # Move vehicle along edge
         start = pos[path_nodes[edge_idx]]
         end = pos[path_nodes[edge_idx + 1]]
         t = max(0, v["pos"]) * total_edges - edge_idx
         x = start[0] + (end[0] - start[0]) * t
         y = start[1] + (end[1] - start[1]) * t
         ax1.plot(x, y, 'o', color=v["color"], markersize=12)
-        v["pos"] += 0.01  # vehicle speed
+        v["pos"] += 0.01
 
-    # Draw network with edge coloring
-    edge_colors = []
-    edge_widths = []
+    # Draw graph
+    edge_colors, edge_widths = [], []
     for u, v in G.edges():
         if traffic.get((u, v), 0) > 0:
-            edge_colors.append("orange")  # currently traversed
+            edge_colors.append("orange")
             edge_widths.append(3)
         elif u in best_path and v in best_path:
-            edge_colors.append("red")  # quantum suggested path
+            edge_colors.append("red")
             edge_widths.append(2)
         else:
             edge_colors.append("gray")
@@ -104,14 +112,39 @@ def animate(frame):
             arrows=True, ax=ax1, edge_color=edge_colors, width=edge_widths)
     nx.draw_networkx_edge_labels(G, pos, edge_labels=nx.get_edge_attributes(G, 'weight'), ax=ax1)
 
-    # Quantum histogram
-    ax2.bar(quantum_counts.keys(), quantum_counts.values(), color='purple')
-    ax2.set_title("Quantum Path Probabilities")
+   # --- Classical vs Quantum side-by-side histogram ---
+    all_paths = list(nx.all_simple_paths(G, start_node, end_node))
+    num_candidates = len(quantum_counts)
+
+    # Classical costs
+    classical_costs = [
+        sum(G[path[i]][path[i+1]]['weight'] for i in range(len(path)-1))
+        for path in all_paths[:num_candidates]
+    ]
+
+    # Normalize classical costs (lower cost = higher score)
+    max_cost = max(classical_costs)
+    classical_scores = [1 - (c / max_cost) for c in classical_costs]
+
+    # Convert quantum counts to probabilities
+    total_shots = sum(quantum_counts.values())
+    quantum_probs = [quantum_counts[i] / total_shots for i in range(num_candidates)]
+
+    # Plot side by side
+    x = range(num_candidates)
+    ax2.bar([i - 0.2 for i in x], classical_scores, width=0.4,
+            color='gray', alpha=0.6, label="Classical (score)")
+    ax2.bar([i + 0.2 for i in x], quantum_probs, width=0.4,
+            color='purple', alpha=0.7, label="Quantum (probability)")
+
+    ax2.set_title("Classical vs Quantum Path Selection")
     ax2.set_xlabel("Path index")
-    ax2.set_ylabel("Counts")
+    ax2.set_ylabel("Score / Probability (0–1)")
+    ax2.set_ylim(0, 1)
+    ax2.legend()
 
 # --- TextBox for vehicle count ---
-axbox = plt.axes([0.25, 0.05, 0.5, 0.05])
+axbox = plt.axes([0.35, 0.05, 0.5, 0.05])
 text_box = TextBox(axbox, 'Vehicles: ', initial="3")
 
 def submit(text):
@@ -126,12 +159,31 @@ def submit(text):
 
 text_box.on_submit(submit)
 
+# --- TextBox for candidate paths (k) ---
+axkbox = plt.axes([0.35, 0.12, 0.5, 0.05])
+k_box = TextBox(axkbox, 'Num of Paths (k): ', initial=str(k_candidates))
+
+def submit_k(text):
+    global k_candidates, best_path, quantum_counts, quantum_shots, vehicles
+    try:
+        k = int(text)
+        if k > 0:
+            k_candidates = k
+            best_path, quantum_counts, quantum_shots = quantum_optimize(G, start_node, end_node, k=k_candidates)
+            vehicles[:] = init_vehicles(len(vehicles))
+            print(f"Updated to top-{k} candidate paths")
+    except ValueError:
+        print("Invalid k entered")
+
+k_box.on_submit(submit_k)
+
+
 # --- RadioButtons for graph selection ---
 axradio = plt.axes([0.05, 0.05, 0.15, 0.15])
 radio = RadioButtons(axradio, ('Demo Graph', 'Large Graph', 'City Graph'))
 
 def graph_selector(label):
-    global G, pos, best_path, quantum_counts, start_node, end_node, vehicles
+    global G, pos, best_path, quantum_counts, quantum_shots, start_node, end_node, vehicles
     if label == 'Demo Graph':
         G, pos = get_demo_graph()
         start_node, end_node = "A", "D"
@@ -142,9 +194,10 @@ def graph_selector(label):
         G, pos = get_city_graph()
         start_node, end_node = "A", "H"
 
-    best_path, quantum_counts = quantum_optimize(G, start_node, end_node)
+    best_path, quantum_counts, quantum_shots = quantum_optimize(G, start_node, end_node)
     vehicles[:] = init_vehicles(len(vehicles))
     print(f"Switched to {label}")
+
 
 radio.on_clicked(graph_selector)
 

--- a/quantum_algorithms.py
+++ b/quantum_algorithms.py
@@ -1,36 +1,100 @@
+import math
 import networkx as nx
-from qiskit import QuantumCircuit
+from itertools import islice
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit_aer import AerSimulator
-from qiskit.visualization import plot_histogram
 
-def quantum_optimize(G, start, end):
+def quantum_optimize(G, start, end, shots=1024, k=10):
     """
     Quantum-assisted shortest path selection using Grover's Algorithm (simulated).
+    Limits to top-k candidate paths for scalability.
     Returns:
-        shortest: list of nodes in the shortest path
-        counts: dict of quantum measurement counts
+        shortest: list of nodes in the shortest path (classical shortest)
+        counts: dict mapping integer path-index -> measured counts
+        shots: number of measurement shots used
     """
-    # Generate all simple paths
-    all_paths = list(nx.all_simple_paths(G, source=start, target=end))
-    if len(all_paths) == 0:
-        return [], {}
 
-    # Determine the shortest path classically
+    # 1) Generate at most k candidate paths using NetworkX's shortest_simple_paths
+    try:
+        all_paths = list(islice(nx.shortest_simple_paths(G, start, end, weight='weight'), k))
+    except nx.NetworkXNoPath:
+        return [], {}, shots
+
+    N_paths = len(all_paths)
+    if N_paths == 0:
+        return [], {}, shots
+
+    # 2) Classical weights
     def path_weight(path):
         return sum(G[path[i]][path[i+1]]['weight'] for i in range(len(path)-1))
 
-    shortest = min(all_paths, key=path_weight)
+    weights = [path_weight(p) for p in all_paths]
+    min_weight = min(weights)
+    marked_indexes = [i for i, w in enumerate(weights) if w == min_weight]
+    shortest = all_paths[marked_indexes[0]]
 
-    # Create a simple quantum circuit (Grover stub)
-    num_qubits = max(1, len(all_paths).bit_length())
-    qc = QuantumCircuit(num_qubits)
-    qc.h(range(num_qubits))
-    qc.measure_all()
+    # 3) Number of qubits needed
+    n_qubits = max(1, (N_paths - 1).bit_length())
+    qc = QuantumCircuit(n_qubits, n_qubits)
 
-    # Simulate the circuit
+    # 4) Initialize in uniform superposition
+    qc.h(range(n_qubits))
+
+    # ---- Grover Oracle (simplified: mark all shortest indexes) ----
+    def apply_oracle():
+        for idx in marked_indexes:
+            bits = format(idx, f'0{n_qubits}b')
+            for i, b in enumerate(bits):
+                if b == '0':
+                    qc.x(i)
+            if n_qubits == 1:
+                qc.z(0)
+            else:
+                qc.h(n_qubits-1)
+                qc.mcx(list(range(n_qubits-1)), n_qubits-1)
+                qc.h(n_qubits-1)
+            for i, b in enumerate(bits):
+                if b == '0':
+                    qc.x(i)
+
+    # ---- Diffuser ----
+    def apply_diffuser():
+        qc.h(range(n_qubits))
+        qc.x(range(n_qubits))
+        if n_qubits == 1:
+            qc.z(0)
+        else:
+            qc.h(n_qubits-1)
+            qc.mcx(list(range(n_qubits-1)), n_qubits-1)
+            qc.h(n_qubits-1)
+        qc.x(range(n_qubits))
+        qc.h(range(n_qubits))
+
+    # 5) Number of Grover iterations
+    M = max(1, len(marked_indexes))
+    N = 2 ** n_qubits
+    r = int(math.floor((math.pi/4) * math.sqrt(N / M)))
+    r = max(1, r)
+
+    for _ in range(r):
+        apply_oracle()
+        apply_diffuser()
+
+    # 6) Measurement
+    qc.measure(range(n_qubits), range(n_qubits))
+
     simulator = AerSimulator()
-    job = simulator.run(qc, shots=1024)
+    job = simulator.run(qc, shots=shots)
     result = job.result()
-    counts = result.get_counts()
+    raw_counts = result.get_counts(qc)
 
-    return shortest, counts
+    # Convert bitstrings to indices
+    counts_by_index = {}
+    for bitstr, c in raw_counts.items():
+        idx = int(bitstr, 2)
+        if idx < N_paths:
+            counts_by_index[idx] = counts_by_index.get(idx, 0) + c
+    for i in range(N_paths):
+        counts_by_index.setdefault(i, 0)
+
+    return shortest, counts_by_index, shots


### PR DESCRIPTION
# Normalized classical path scores

- Classical costs are inverted and scaled to the 0–1 range: score = 1 - (cost / max_cost).

- This ensures that shorter paths (better) appear as taller bars.

# Converted quantum counts to probabilities

- Counts are divided by total shots, producing values between 0 and 1.

- This makes quantum amplification directly comparable to classical scores.

# Updated histogram plotting

- Bars are displayed side by side for each candidate path:

- Gray = classical score

- Purple = quantum probability

- Y-axis fixed to 0–1 for clarity.